### PR TITLE
Extra disks creation when SNO

### DIFF
--- a/ansible-vars-kvm.yaml
+++ b/ansible-vars-kvm.yaml
@@ -10,6 +10,8 @@ worker_cpu: 4
 n_worker: 0
 master_mem: '32000'
 master_cpu: 8
+extra_disks: 1
+extra_disk_size: 100
 htpasswd_pass: 'Redhat@123'
 ssh_rsa: >-
   ssh-rsa AAAAB3Nza...

--- a/ansible-vars-kvm.yaml
+++ b/ansible-vars-kvm.yaml
@@ -10,7 +10,7 @@ worker_cpu: 4
 n_worker: 0
 master_mem: '32000'
 master_cpu: 8
-extra_disks: 1
+extra_disks: 0
 extra_disk_size: 100
 htpasswd_pass: 'Redhat@123'
 ssh_rsa: >-

--- a/create-cluster-upi-kvm.yaml
+++ b/create-cluster-upi-kvm.yaml
@@ -414,11 +414,21 @@
       when: sno == "false"
 
     - name: Create virtual machines disks when SNO
-      ansible.builtin.command: "qemu-img create -f qcow2 {{ clustername }}-master-0.qcow2 120G"
-      args:
-        chdir: "{{ clusters_dir }}/{{ clustername }}"
-      register: qcow2master
-      changed_when: true
+      block:
+        - name: Create primary disk
+          ansible.builtin.command: "qemu-img create -f qcow2 {{ clustername }}-master-0.qcow2 120G"
+          args:
+            chdir: "{{ clusters_dir }}/{{ clustername }}"
+          register: qcow2master
+          changed_when: true
+        - name: Create extra disks
+          ansible.builtin.command: "qemu-img create -f qcow2 {{ clustername }}-extra-disk-{{ item }}.qcow2 {{ extra_disk_size }}G"
+          args:
+            chdir: "{{ clusters_dir }}/{{ clustername }}"
+          loop: "{{ range(1, extra_disks + 1) }}"
+          when: extra_disks > 0
+          register: extra_disks_result
+          changed_when: true
       when: sno == "true"
 
     - name: Create virtual machines disks when 3 node cluster
@@ -506,6 +516,9 @@
       ansible.builtin.command: virt-install --import --name {{ clustername }}-master-0   \
             --disk {{ clusters_dir }}/{{ clustername }}/{{ clustername }}-master-0.qcow2,bus=virtio,size=120 \
             --disk {{ clusters_dir }}/{{ clustername }}/rhcos-master.iso,device=cdrom \
+            {% for i in range(1, extra_disks + 1) %}
+            --disk {{ clusters_dir }}/{{ clustername }}/{{ clustername }}-extra-disk-{{ i }}.qcow2,bus=virtio,size={{ extra_disk_size }} \
+            {% endfor %}
             --boot hd,cdrom --check path_in_use=off --noreboot --noautoconsole \
             --ram "{{ master_mem }}" --cpu host --vcpus "{{ master_cpu }}" --os-variant rhel9-unknown --network network={{ kvmnetwork }},model=virtio
       register: createnodes


### PR DESCRIPTION
Added option to create extra disks on SNO VM machine creation task.
These disks could be used for day2 operations for persistent storage (using LVMOperator).