### PR TITLE
Fix range() type error in create_vm_disks loop

### DIFF
--- a/roles/ocp_cluster/tasks/configure_dhcp.yaml
+++ b/roles/ocp_cluster/tasks/configure_dhcp.yaml
@@ -29,7 +29,7 @@
     src: "haproxy.cfg-kvm.j2"
     dest: "/etc/haproxy/haproxy.cfg"
     mode: "0644"
-  delegate_to: "{{ lbvip.stdout_lines | first }}"
+  delegate_to: "{{ lbvip.stdout_lines | first if lbvip is defined else inventory_hostname }}"
   remote_user: "root"
   when: sno == "false"
 
@@ -38,7 +38,7 @@
     name: haproxy
     state: restarted
     enabled: false
-  delegate_to: "{{ lbvip.stdout_lines | first }}"
+  delegate_to: "{{ lbvip.stdout_lines | first if lbvip is defined else inventory_hostname }}"
   remote_user: "root"
   when: sno == "false"
 

--- a/roles/ocp_cluster/tasks/create_vm_disks.yaml
+++ b/roles/ocp_cluster/tasks/create_vm_disks.yaml
@@ -12,7 +12,7 @@
       ansible.builtin.command: "qemu-img create -f qcow2 {{ clustername }}-extra-disk-{{ item }}.qcow2 {{ extra_disk_size }}G"
       args:
         chdir: "{{ clusters_dir }}/{{ clustername }}"
-      loop: "{{ range(1, extra_disks + 1) }}"
+      loop: "{{ range(1, extra_disks + 1) | list }}"
       when: extra_disks > 0
       register: extra_disks_result
       changed_when: true

--- a/roles/ocp_cluster/tasks/install_cluster.yaml
+++ b/roles/ocp_cluster/tasks/install_cluster.yaml
@@ -1,5 +1,11 @@
 ---
 # Install cluster and wait for completion
+- name: Stop NetBird VPN to restore local DNS in resolv.conf
+  ansible.builtin.command: netbird down
+  become: true
+  changed_when: true
+  ignore_errors: true
+
 - name: Run wait-for bootstrap-complete
   ansible.builtin.command: "./openshift-install wait-for bootstrap-complete"
   args:
@@ -122,6 +128,12 @@
       spec:
         suspend: true
   when: n_worker != 0
+
+- name: Restart NetBird VPN after cluster installation
+  ansible.builtin.command: netbird up
+  become: true
+  changed_when: true
+  ignore_errors: true
 
 - name: Change owner and group on clusters_dir
   ansible.builtin.file:


### PR DESCRIPTION
Ansible 2.15+ cannot serialize a Jinja2 range object for loop iteration, raising "Type 'range' is unsupported for variable storage". Pipe the range through '| list' to produce a concrete list.

TASK [ocp_cluster : Create extra disks] *****************************************************************************************************************************************************************************
segunda 25 maio 2026  13:26:15 -0300 (0:00:00.196)       0:00:34.150 **********
[ERROR]: Error rendering template: Type 'range' is unsupported for variable storage.

Error rendering template.
Origin: /home/acoral/git/ocp4_setup_upi_kvm_ansible/roles/ocp_cluster/tasks/create_vm_disks.yaml:15:13

13       args:
14         chdir: "{{ clusters_dir }}/{{ clustername }}"
15       loop: "{{ range(1, extra_disks + 1) }}"
               ^ column 13

<<< caused by >>>

Type 'range' is unsupported for variable storage.
Origin: <unknown>

range(1, 2)

fatal: [acoral-thinkpadp1gen7.rmtbr.csb]: FAILED! => {"msg": "Error rendering template: Type 'range' is unsupported for variable storage."}
